### PR TITLE
Updated README files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,64 @@
-# Generic MHTGR Model
+# Generic Modular High Temperature Gas Cooled Reactor (MHTGR) Model
 
-This repository includes generic MHTGR model in various formats. Model versions are controlled using git tags.
+This repository contains the generic Modular High Temperature Gas Cooled Reactor (MHTGR) Probabilistic Risk Assessment (PRA) model in multiple formats, including SAPHIRE and CAFTA. The model is designed to support risk-informed operational decisions and benchmarking studies for advanced reactor concepts.
+
+## Model Overview
+
+The MHTGR PRA model includes a comprehensive set of initiating events, event trees, and fault trees, capturing a wide range of internal and external hazards relevant to modular high temperature gas-cooled reactor technology.
+
+### Event Trees
+
+- Primary coolant leaks
+- Small steam generator leaks
+- Moderate steam generator leaks
+- Loss of HTS cooling (HTS)
+- Loss of offsite power (LOOP)
+- Control rod withdrawal (CRW)
+- Anticipated transients requiring scram (ATRS)
+
+### Fault Trees
+
+- CRW
+- Shutdown cooling system (SCS)
+- Automatic Steam Generator Dump
+- Reaccor Trip
+- Moisture Monitor Detection
+- Automatic Steam Generator Isolation
+- Steam Generator Relief Train Response
+- Reactor Cavity Cooling System
+- HPS Pumpdown
+
+### Top Events of Fault Trees
+
+- Loss of HTS cooling
+- Turbine building closed cooling water subsystem failure
+- Reactor plant cooling water subsystem failure
+- Loss of Class IE 120 VAC uninterruptible power supply
+- SCS failure in at least one module where HTS failed
+- Failure of SCS when one module requires cooling
+- Loss of SCS cooling when four modules require cooling
+- Heater failure
+- Demineralizer failures
+- Circulating water subsystem failure
+- Service water subsystem failure
+
+### Basic Events and Repairs
+
+The model includes detailed basic event definitions and corresponding repair actions, covering failures and repairs for:
+- Helium circulators (steam and electric driven)
+- Blowers/fans
+- Steam generators, heat exchangers, condensers, and auxiliary boilers
+- Pumps (motor and steam driven, feedwater, condensate, air ejector)
+- Tanks, welds, flanges, gaskets, pressurizer, demineralizer
+- Piping, valves (various types), diesel generators
+- Instrumentation and control systems
+- Service systems (instrument air, service water, offsite power)
+- Motors, transformers, batteries, electric conductors, cables, circuit breakers, inverters
+
+Failure and repair data are provided in the `basic_events_and_repairs.csv` file.
+
+## File Structure
+
+- `data/v0.7/` — CAFTA model files
+- `data/v0.8/` — SAPHIRE model files
+- `data/README.md` — Tabulated basic event and repair data

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The MHTGR PRA model includes a comprehensive set of initiating events, event tre
 - CRW
 - Shutdown cooling system (SCS)
 - Automatic Steam Generator Dump
-- Reaccor Trip
+- Reactor Trip
 - Moisture Monitor Detection
 - Automatic Steam Generator Isolation
 - Steam Generator Relief Train Response

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Generic Modular High Temperature Gas Cooled Reactor (MHTGR) Model
 
-This repository contains the generic Modular High Temperature Gas Cooled Reactor (MHTGR) Probabilistic Risk Assessment (PRA) model in multiple formats, including SAPHIRE and CAFTA. The model is designed to support risk-informed operational decisions and benchmarking studies for advanced reactor concepts.
+This repository contains the generic Modular High Temperature Gas Cooled Reactor (MHTGR) PRA models in multiple formats, including SAPHIRE and CAFTA. The model is designed to support risk-informed operational decisions and benchmarking studies for advanced reactor concepts.
 
 ## Model Overview
 

--- a/data/README.md
+++ b/data/README.md
@@ -157,132 +157,132 @@
 
 | Table | identification | subsystem | Failure mode | TC | Description |
 |-------|---------------|-----------|--------------|----|-------------|
-| b-18 | Helium Circulators steam driven, water lubricated | all | malfunction | B18-SD-ALL-MALFUNCTION | Helium Circulators steam driven, water lubricated - all - malfunction |
-| b-18 | Helium Circulators steam driven, water lubricated | machine drive and lubrication | fail to operate | B18-SD-MACHINE-FTO | Helium Circulators steam driven, water lubricated - machine drive and lubrication - fail to operate |
-| b-18 | Helium Circulators steam driven, water lubricated | Power supply | loss of steam | B18-SD-POWERSUPPLY-LOS | Helium Circulators steam driven, water lubricated - Power supply - loss of steam |
-| b-18 | Electric motor driven, oil lubricated | Control system | fail to operate | B18-SD-CONTROL-FTO | Electric motor driven, oil lubricated - Control system - fail to operate |
-| b-18 | Electric motor driven, oil lubricated | Control system | out of limits | B18-SD-CONTROL-OUTLIMIT | Electric motor driven, oil lubricated - Control system - out of limits |
-| b-18 | Electric motor driven, oil lubricated | all | malfunction | B18-ED-ALL-MALFUNCTION | Electric motor driven, oil lubricated - all - malfunction |
-| b-18 | Electric motor driven, oil lubricated | machine drive and lubrication | fail to operate | B18-ED-MACHINE-FTO | Electric motor driven, oil lubricated - machine drive and lubrication - fail to operate |
-| b-18 | Electric motor driven, oil lubricated | Power supply | loss of electric power | B18-ED-POWERSUPPLY-LOEP | Electric motor driven, oil lubricated - Power supply - loss of electric power |
-| b-18 | Electric motor driven, oil lubricated | Control system | fail to operate | B18-ED-CONTROL-FTO | Electric motor driven, oil lubricated - Control system - fail to operate |
-| b-18 | Electric motor driven, oil lubricated | Control system | out of limits | B18-ED-CONTROL-OUTLIMIT | Electric motor driven, oil lubricated - Control system - out of limits |
-| b-18 | Electric motor driven, oil lubricated | Control system | fail to start | B18-ED-CONTROL-FTS | Electric motor driven, oil lubricated - Control system - fail to start |
-| b-18 | Electric motor driven, magnetic bearings | machine drive and lubrication | fail to operate | B18-MB-MACHINE-FTO | Electric motor driven, magnetic bearings - machine drive and lubrication - fail to operate |
-| b-18 | Electric motor driven, magnetic bearings | Power supply | loss of electric power | B18-MB-POWERSUPPLY-LOEP | Electric motor driven, magnetic bearings - Power supply - loss of electric power |
-| b-18 | Electric motor driven, magnetic bearings | Control system | fail to operate | B18-MB-CONTROL-FTO | Electric motor driven, magnetic bearings - Control system - fail to operate |
-| b-18 | Electric motor driven, magnetic bearings | magnetic bearings | fail to operate | B18-MB-BEARING-FTO | Electric motor driven, magnetic bearings - magnetic bearings - fail to operate |
-| b-18 | Electric motor driven, magnetic bearings | solid state control | fail to operate | B18-MB-SSCONTROL-FTO | Electric motor driven, magnetic bearings - solid state control - fail to operate |
-| b-18 | blowers/fans | all | fail to start | B18-B/F-ALL-FTS | blowers/fans - all - fail to start |
-| b-18 | blowers/fans | all | fail to run | B18-B/F-ALL-FTR | blowers/fans - all - fail to run |
-| b-19 | SG | Tubes | leak | B19-SG-TUBE-LEAK | SG - Tubes - leak |
-| b-19 | heat exchanger | general | all | B19-HTX-GENERAL-ALL | heat exchanger - general - all |
-| b-19 | feedwater heater | Tubes | leak | B19-FW-TUBE-LEAK | feedwater heater - Tubes - leak |
-| b-19 | cooler | all | all | B19-COOLR-ALL-ALL | cooler - all - all |
-| b-19 | desuperheater | all | all | B19-DESUPR-ALL-ALL | desuperheater - all - all |
-| b-19 | condenser | Tubes | leak | B19-CONDENSER-TUBE-LEAK | condenser - Tubes - leak |
-| b-19 | condenser | vacuum | rapid loss of vacuum | B19-CONDENSER-VACUUM-LOV | condenser - vacuum - rapid loss of vacuum |
-| b-19 | air blast heat | all | fail to start | B19-AIRHEAT-ALL-FTS | air blast heat - all - fail to start |
-| b-19 | air blast heat | all | fail to run | B19-AIRHEAT-ALL-FTR | air blast heat - all - fail to run |
-| b-19 | deaerator | all | failure of level control | B19-DEAER-ALL-LEVEL | deaerator - all - failure of level control |
-| b-19 | auxiliary boiler | all | fail to start | B19-AUXBOILER-ALL-FTS | auxiliary boiler - all - fail to start |
-| b-19 | auxiliary boiler | all | fail to run | B19-AUXBOILER-ALL-FTR | auxiliary boiler - all - fail to run |
-| b-19 | auxiliary boiler | all | fail to deliver steam in T minutes | B19-AUXBOILER-ALL-STEAM | auxiliary boiler - all - fail to deliver steam in T minutes |
-| b-20 | pumps | general | all | B20-PUMPS-GENERAL-ALL | pumps - general - all |
-| b-20 | pumps | general | intake blocakge | B20-PUMPS-GENERAL-BLOCK | pumps - general - intake blocakge |
-| b-20 | pumps | motor driven | fail to operate | B20-PUMPS-ED-FTO | pumps - motor driven - fail to operate |
-| b-20 | pumps | motor driven | fail to run in extreme environment | B20-PUMPS-ED-FTR/X | pumps - motor driven - fail to run in extreme environment |
-| b-20 | pumps | steam driven | fail to run | B20-PUMPS-SD-FTR | pumps - steam driven - fail to run |
-| b-20 | pumps | feedwater | fail to operate | B20-PUMPS-FW-FTO | pumps - feedwater - fail to operate |
-| b-20 | pumps | feedwater | loss of drive | B20-PUMPS-FW-LOD | pumps - feedwater - loss of drive |
-| b-20 | pumps | feedwater | loss of power supply | B20-PUMPS-FW-LOPS | pumps - feedwater - loss of power supply |
-| b-20 | pumps | steam driven | loss of drive | B20-PUMPS-SD-LOD | pumps - steam driven - loss of drive |
-| b-20 | pumps | steam driven | loss of power supply | B20-PUMPS-SD-LOPS | pumps - steam driven - loss of power supply |
-| b-20 | pumps | low pressure feedwater | fail to run | B20-PUMPS-FW/LP-FTR | pumps - low pressure feedwater - fail to run |
-| b-20 | pumps | air ejector | fail to run | B20-PUMPS-AIREJECT-FTR | pumps - air ejector - fail to run |
-| b-20 | pumps | condensate | fail to run | B20-PUMPS-CONDENSATE-FTR | pumps - condensate - fail to run |
-| b-21 | tanks | general | all | B21-TNK-GENERAL-ALL | tanks - general - all |
-| b-21 | tanks | general | disruptive failure | B21-TNK-GENERAL-DISRUPTIVE | tanks - general - disruptive failure |
-| b-21 | welds | all | leak | B21-WELD-ALL-LEAK | welds - all - leak |
-| b-21 | flanges | all | rupture | B21-FLANGE-ALL-RUPTURE | flanges - all - rupture |
-| b-21 | gaskets | all | leak | B21-GASKET-ALL-LEAK | gaskets - all - leak |
-| b-21 | pressurizer | all | leak | B21-PRZR-ALL-LEAK | pressurizer - all - leak |
-| b-21 | demineralizer | all | leak | B21-DEMIN-ALL-LEAK | demineralizer - all - leak |
-| b-22 | piping | general | disruptive failure | B22-PIPE-GENERAL-DISRUPTIVE | piping - general - disruptive failure |
-| b-23 | valves | general | all | B23-VLVE-GENERAL-ALL | valves - general - all |
-| b-23 | valves | motor operated | fail to change state | B23-VLVE-MOV-FTO | valves - motor operated - fail to change state |
-| b-23 | valves | motor operated modulating including valve operator | fail to operate | B23-VLVE-MOD-FTO | valves - motor operated modulating including valve operator - fail to operate |
-| b-23 | valves | motor operated modulating including valve operator | external leak | B23-VLVE-MOD-EXTLEAK | valves - motor operated modulating including valve operator - external leak |
-| b-23 | valves | motor operated modulating including valve operator | plugged | B23-VLVE-MOD-PLUG | valves - motor operated modulating including valve operator - plugged |
-| b-23 | valves | motor operated modulating including valve operator | rupture | B23-VLVE-MOD-RUPTURE | valves - motor operated modulating including valve operator - rupture |
-| b-23 | valves | air solenoid | fail to change state | B23-VLVE-AIRSOLENOID-FTO | valves - air solenoid - fail to change state |
-| b-23 | valves | air solenoid modulating includes valve operator | fail to operate | B23-VLVE-AIRMOD-FTO | valves - air solenoid modulating includes valve operator - fail to operate |
-| b-23 | valves | air solenoid modulating includes valve operator | external leak | B23-VLVE-AIRMOD-EXTLEAK | valves - air solenoid modulating includes valve operator - external leak |
-| b-23 | valves | air solenoid modulating includes valve operator | rupture | B23-VLVE-AIRMOD-RUPTURE | valves - air solenoid modulating includes valve operator - rupture |
-| b-23 | valves | manual | fail to operate | B23-VLVE-MANUAL-FTO | valves - manual - fail to operate |
-| b-23 | valves | manual | external leak | B23-VLVE-MANUAL-EXTLEAK | valves - manual - external leak |
-| b-23 | valves | check | fail to change state | B23-VLVE-CHK-FTO | valves - check - fail to change state |
-| b-23 | valves | check | reverse leak | B23-VLVE-CHK-RVRSLEAK | valves - check - reverse leak |
-| b-23 | valves | check | external leak | B23-VLVE-CHK-EXTLEAK | valves - check - external leak |
-| b-23 | valves | check | rupture | B23-VLVE-CHK-RUPTURE | valves - check - rupture |
-| b-23 | valves | hydraulic valve actuator | all | B23-VLVE-HYDRLIC-ALL | valves - hydraulic valve actuator - all |
-| b-23 | valves | pneumatic valve actuator | all | B23-VLVE-PNEUM-ALL | valves - pneumatic valve actuator - all |
-| b-23 | valves | relief (steam/water) | fail to open | B23-VLVE-RELIEFS/W-FTO | valves - relief (steam/water) - fail to open |
-| b-23 | valves | relief (steam/water) | spurious/premature operation | B23-VLVE-RELIEFS/W-SOP | valves - relief (steam/water) - spurious/premature operation |
-| b-23 | valves | relief (steam/water) | fail to reclose | B23-VLVE-RELIEFS/W-RECLOSE | valves - relief (steam/water) - fail to reclose |
-| b-23 | valves | motor operated helium isolation ring valve with redundant motors | fail to change state | B23-VLVE-HEMOVISOLATE-FTO | valves - motor operated helium isolation ring valve with redundant motors - fail to change state |
-| b-23 | valves | motor operated helium isolation ring valve with redundant motors | spurious/premature operation | B23-VLVE-HEMOVISOLATE-SOP | valves - motor operated helium isolation ring valve with redundant motors - spurious/premature operation |
-| b-23 | valves | motor operated helium isolation ring valve with redundant motors | bypass leak | B23-VLVE-HEMOVISOLATE-BYPSLEAK | valves - motor operated helium isolation ring valve with redundant motors - bypass leak |
-| b-23 | valves | passive helium isolation check valve | fail to change state | B23-VLVE-HEPASSISOLATE-FTO | valves - passive helium isolation check valve - fail to change state |
-| b-23 | valves | passive helium isolation check valve | spurious/premature operation | B23-VLVE-HEPASSISOLATE-SOP | valves - passive helium isolation check valve - spurious/premature operation |
-| b-23 | valves | passive helium isolation check valve | bypass leak | B23-VLVE-HEPASSISOLATE-BYPSLEAK | valves - passive helium isolation check valve - bypass leak |
-| b-23 | valves | orifice flow valve (helium) | external leak/rupture | B23-VLVE-FLOW-EXTLEAK | valves - orifice flow valve (helium) - external leak/rupture |
-| b-24 | diesel generator | all | fail to start and load on first try | B24-DG-ALL-FTS | diesel generator - all - fail to start and load on first try |
-| b-24 | diesel generator | all | standby failures | B24-DG-ALL-STNDBY | diesel generator - all - standby failures |
-| b-24 | diesel generator | all | fail to run | B24-DG-ALL-FTR | diesel generator - all - fail to run |
-| b-25 | Instrumentation | general | all | B25-INSTRUMNT-GENERAL-ALL | Instrumentation - general - all |
-| b-25 | Instrumentation | solid state instrumentation | fail to operate | B25-INSTRUMNT-SS-FTO | Instrumentation - solid state instrumentation - fail to operate |
-| b-25 | Instrumentation | solid state instrumentation | no output | B25-INSTRUMNT-SS-OUTPUT | Instrumentation - solid state instrumentation - no output |
-| b-25 | Instrumentation | solid state instrumentation | calibration shift | B25-INSTRUMNT-SS-CALIBRATION | Instrumentation - solid state instrumentation - calibration shift |
-| b-25 | Instrumentation | signal modifier | fail to operate | B25-INSTRUMNT-SIGMOD-FTO | Instrumentation - signal modifier - fail to operate |
-| b-25 | Instrumentation | signal modifier | setpoint drift | B25-INSTRUMNT-SIGMOD-DRIFT | Instrumentation - signal modifier - setpoint drift |
-| b-25 | Instrumentation | neutron flux sensor | fail to operate | B25-INSTRUMNT-NSENSOR-FTO | Instrumentation - neutron flux sensor - fail to operate |
-| b-25 | Instrumentation | pressure sensore | fail to operate | B25-INSTRUMNT-PRESENSOR-FTO | Instrumentation - pressure sensore - fail to operate |
-| b-25 | Instrumentation | temperature sensor | out of limits | B25-INSTRUMNT-TMPSENSOR-LIMITS | Instrumentation - temperature sensor - out of limits |
-| b-25 | Instrumentation | speed sensore | out of limits | B25-INSTRUMNT-SPDSENSOR-LIMIT | Instrumentation - speed sensore - out of limits |
-| b-25 | Instrumentation | moisture monitor sensor | out of limits | B25-INSTRUMNT-MOSTSENSOR-LIMIT | Instrumentation - moisture monitor sensor - out of limits |
-| b-25 | Instrumentation | position level sensor | out of limits | B25-INSTRUMNT-LVLSENSOR-LIMIT | Instrumentation - position level sensor - out of limits |
-| b-25 | Instrumentation | flow and level sensor | fail to operate | B25-INSTRUMNT-FLWSENSOR-FTO | Instrumentation - flow and level sensor - fail to operate |
-| b-26 | control | main steam pressure control | fail to operate | B26-CNTRL-MSPRESSURE-FTO | control - main steam pressure control - fail to operate |
-| b-26 | control | main steam pressure control | drift | B26-CNTRL-MSPRESSURE-DRIFT | control - main steam pressure control - drift |
-| b-26 | control | regulating rod control | fail to operate | B26-CNTRL-REGULATE-FTO | control - regulating rod control - fail to operate |
-| b-26 | control | regulating rod control | drift | B26-CNTRL-REGULATE-DRIFT | control - regulating rod control - drift |
-| b-26 | control | plant protection control | spurious signal terminates feedwater flow | B26-CNTRL-PROTECT-SOP | control - plant protection control - spurious signal terminates feedwater flow |
-| b-26 | control | signal conditioning system | fail to operate | B26-CNTRL-SIGCOND-FTO | control - signal conditioning system - fail to operate |
-| b-26 | control | steamline radiation monitoring | fail to operate | B26-CNTRL-RADMONIT-FTO | control - steamline radiation monitoring - fail to operate |
-| b-26 | control | turbine control | out of limits | B26-CNTRL-TURBINE-LIMIT | control - turbine control - out of limits |
-| b-26 | control | condensor control | out of limits | B26-CNTRL-CNDNSER-LIMIT | control - condensor control - out of limits |
-| b-26 | control | pressure switch | fail to operate | B26-CNTRL-PRESWITCH-FTO | control - pressure switch - fail to operate |
-| b-27 | service | instrument air | fail to operate | B27-SERVICE-INSTRUMNTAIR-FTO | service - instrument air - fail to operate |
-| b-27 | service | service water | fail to operate | B27-SERVICE-SWS-FTO | service - service water - fail to operate |
-| b-27 | service | offsite power | all | B27-SERVICE-OFFSITEPOWER-ALL | service - offsite power - all |
-| b-28 | motors | electric motors | fail to operate | B28-MOTOR-EM-FTO | motors - electric motors - fail to operate |
-| b-28 | motors | electric motors | fail to run in extreme environment | B28-MOTOR-EM-FTR/X | motors - electric motors - fail to run in extreme environment |
-| b-29 | transformers | general | all | B29-TRNSFRMR-GENERAL-ALL | transformers - general - all |
-| b-29 | transformers | high voltage transformer | trip off line | B29-TRNSFRMR-HIGHV-TRIP | transformers - high voltage transformer - trip off line |
-| b-29 | transformers | low voltage transformer | trip off line | B29-TRNSFRMR-LOWV-TRIP | transformers - low voltage transformer - trip off line |
-| b-29 | transformers | low voltage transformer | open/short windings | B29-TRNSFRMR-LOWV-SHORT | transformers - low voltage transformer - open/short windings |
-| b-29 | transformers | low voltage transformer | short to ground | B29-TRNSFRMR-LOWV-GROUND | transformers - low voltage transformer - short to ground |
-| b-30 | batteries | general | all | B30-BATTERY-GENERAL-ALL | batteries - general - all |
-| b-30 | batteries | general | low output shortened | B30-BATTERY-GENERAL-SHORTEN | batteries - general - low output shortened |
-| b-30 | batteries | general | voltage regulation | B30-BATTERY-GENERAL-REGULATE | batteries - general - voltage regulation |
-| b-30 | batteries | charger | all | B30-BATTERY-CHARGER-ALL | batteries - charger - all |
-| b-31 | electric conductor | general | all | B31-CONDCT-GENERAL-ALL | electric conductor - general - all |
-| b-31 | power cable | general | open | B31-CONDCT-CABLE-OPEN | power cable - general - open |
-| b-31 | power cable | general | ground | B31-CONDCT-CABLE-GROUND | power cable - general - ground |
-| b-31 | signal wire | general | open | B31-CONDCT-WIRE-OPEN | signal wire - general - open |
-| b-31 | signal wire | general | ground | B31-CONDCT-WIRE-GROUND | signal wire - general - ground |
-| b-31 | signal wire | general | short to power | B31-CONDCT-WIRE-SHORT | signal wire - general - short to power |
-| b-32 | Circuit breaker | general | fail to change state | B32-BRKR-GENERAL-FTO | Circuit breaker - general - fail to change state |
-| b-32 | Circuit breaker | general | premature transfer | B32-BRKR-GENERAL-SOP | Circuit breaker - general - premature transfer |
-| b-33 | electric | inverter | fail to operate | B33-ELECTRIC-INVRTR-FTO | electric - inverter - fail to operate |
+| B-18 | Helium Circulators steam driven, water lubricated | all | malfunction | B18-SD-ALL-MALFUNCTION | Helium Circulators steam driven, water lubricated - all - malfunction |
+| B-18 | Helium Circulators steam driven, water lubricated | machine drive and lubrication | fail to operate | B18-SD-MACHINE-FTO | Helium Circulators steam driven, water lubricated - machine drive and lubrication - fail to operate |
+| B-18 | Helium Circulators steam driven, water lubricated | Power supply | loss of steam | B18-SD-POWERSUPPLY-LOS | Helium Circulators steam driven, water lubricated - Power supply - loss of steam |
+| B-18 | Electric motor driven, oil lubricated | Control system | fail to operate | B18-SD-CONTROL-FTO | Electric motor driven, oil lubricated - Control system - fail to operate |
+| B-18 | Electric motor driven, oil lubricated | Control system | out of limits | B18-SD-CONTROL-OUTLIMIT | Electric motor driven, oil lubricated - Control system - out of limits |
+| B-18 | Electric motor driven, oil lubricated | all | malfunction | B18-ED-ALL-MALFUNCTION | Electric motor driven, oil lubricated - all - malfunction |
+| B-18 | Electric motor driven, oil lubricated | machine drive and lubrication | fail to operate | B18-ED-MACHINE-FTO | Electric motor driven, oil lubricated - machine drive and lubrication - fail to operate |
+| B-18 | Electric motor driven, oil lubricated | Power supply | loss of electric power | B18-ED-POWERSUPPLY-LOEP | Electric motor driven, oil lubricated - Power supply - loss of electric power |
+| B-18 | Electric motor driven, oil lubricated | Control system | fail to operate | B18-ED-CONTROL-FTO | Electric motor driven, oil lubricated - Control system - fail to operate |
+| B-18 | Electric motor driven, oil lubricated | Control system | out of limits | B18-ED-CONTROL-OUTLIMIT | Electric motor driven, oil lubricated - Control system - out of limits |
+| B-18 | Electric motor driven, oil lubricated | Control system | fail to start | B18-ED-CONTROL-FTS | Electric motor driven, oil lubricated - Control system - fail to start |
+| B-18 | Electric motor driven, magnetic bearings | machine drive and lubrication | fail to operate | B18-MB-MACHINE-FTO | Electric motor driven, magnetic bearings - machine drive and lubrication - fail to operate |
+| B-18 | Electric motor driven, magnetic bearings | Power supply | loss of electric power | B18-MB-POWERSUPPLY-LOEP | Electric motor driven, magnetic bearings - Power supply - loss of electric power |
+| B-18 | Electric motor driven, magnetic bearings | Control system | fail to operate | B18-MB-CONTROL-FTO | Electric motor driven, magnetic bearings - Control system - fail to operate |
+| B-18 | Electric motor driven, magnetic bearings | magnetic bearings | fail to operate | B18-MB-BEARING-FTO | Electric motor driven, magnetic bearings - magnetic bearings - fail to operate |
+| B-18 | Electric motor driven, magnetic bearings | solid state control | fail to operate | B18-MB-SSCONTROL-FTO | Electric motor driven, magnetic bearings - solid state control - fail to operate |
+| B-18 | blowers/fans | all | fail to start | B18-B/F-ALL-FTS | blowers/fans - all - fail to start |
+| B-18 | blowers/fans | all | fail to run | B18-B/F-ALL-FTR | blowers/fans - all - fail to run |
+| B-19 | SG | Tubes | leak | B19-SG-TUBE-LEAK | SG - Tubes - leak |
+| B-19 | heat exchanger | general | all | B19-HTX-GENERAL-ALL | heat exchanger - general - all |
+| B-19 | feedwater heater | Tubes | leak | B19-FW-TUBE-LEAK | feedwater heater - Tubes - leak |
+| B-19 | cooler | all | all | B19-COOLR-ALL-ALL | cooler - all - all |
+| B-19 | desuperheater | all | all | B19-DESUPR-ALL-ALL | desuperheater - all - all |
+| B-19 | condenser | Tubes | leak | B19-CONDENSER-TUBE-LEAK | condenser - Tubes - leak |
+| B-19 | condenser | vacuum | rapid loss of vacuum | B19-CONDENSER-VACUUM-LOV | condenser - vacuum - rapid loss of vacuum |
+| B-19 | air blast heat | all | fail to start | B19-AIRHEAT-ALL-FTS | air blast heat - all - fail to start |
+| B-19 | air blast heat | all | fail to run | B19-AIRHEAT-ALL-FTR | air blast heat - all - fail to run |
+| B-19 | deaerator | all | failure of level control | B19-DEAER-ALL-LEVEL | deaerator - all - failure of level control |
+| B-19 | auxiliary boiler | all | fail to start | B19-AUXBOILER-ALL-FTS | auxiliary boiler - all - fail to start |
+| B-19 | auxiliary boiler | all | fail to run | B19-AUXBOILER-ALL-FTR | auxiliary boiler - all - fail to run |
+| B-19 | auxiliary boiler | all | fail to deliver steam in T minutes | B19-AUXBOILER-ALL-STEAM | auxiliary boiler - all - fail to deliver steam in T minutes |
+| B-20 | pumps | general | all | B20-PUMPS-GENERAL-ALL | pumps - general - all |
+| B-20 | pumps | general | intake blocakge | B20-PUMPS-GENERAL-BLOCK | pumps - general - intake blocakge |
+| B-20 | pumps | motor driven | fail to operate | B20-PUMPS-ED-FTO | pumps - motor driven - fail to operate |
+| B-20 | pumps | motor driven | fail to run in extreme environment | B20-PUMPS-ED-FTR/X | pumps - motor driven - fail to run in extreme environment |
+| B-20 | pumps | steam driven | fail to run | B20-PUMPS-SD-FTR | pumps - steam driven - fail to run |
+| B-20 | pumps | feedwater | fail to operate | B20-PUMPS-FW-FTO | pumps - feedwater - fail to operate |
+| B-20 | pumps | feedwater | loss of drive | B20-PUMPS-FW-LOD | pumps - feedwater - loss of drive |
+| B-20 | pumps | feedwater | loss of power supply | B20-PUMPS-FW-LOPS | pumps - feedwater - loss of power supply |
+| B-20 | pumps | steam driven | loss of drive | B20-PUMPS-SD-LOD | pumps - steam driven - loss of drive |
+| B-20 | pumps | steam driven | loss of power supply | B20-PUMPS-SD-LOPS | pumps - steam driven - loss of power supply |
+| B-20 | pumps | low pressure feedwater | fail to run | B20-PUMPS-FW/LP-FTR | pumps - low pressure feedwater - fail to run |
+| B-20 | pumps | air ejector | fail to run | B20-PUMPS-AIREJECT-FTR | pumps - air ejector - fail to run |
+| B-20 | pumps | condensate | fail to run | B20-PUMPS-CONDENSATE-FTR | pumps - condensate - fail to run |
+| B-21 | tanks | general | all | B21-TNK-GENERAL-ALL | tanks - general - all |
+| B-21 | tanks | general | disruptive failure | B21-TNK-GENERAL-DISRUPTIVE | tanks - general - disruptive failure |
+| B-21 | welds | all | leak | B21-WELD-ALL-LEAK | welds - all - leak |
+| B-21 | flanges | all | rupture | B21-FLANGE-ALL-RUPTURE | flanges - all - rupture |
+| B-21 | gaskets | all | leak | B21-GASKET-ALL-LEAK | gaskets - all - leak |
+| B-21 | pressurizer | all | leak | B21-PRZR-ALL-LEAK | pressurizer - all - leak |
+| B-21 | demineralizer | all | leak | B21-DEMIN-ALL-LEAK | demineralizer - all - leak |
+| B-22 | piping | general | disruptive failure | B22-PIPE-GENERAL-DISRUPTIVE | piping - general - disruptive failure |
+| B-23 | valves | general | all | B23-VLVE-GENERAL-ALL | valves - general - all |
+| B-23 | valves | motor operated | fail to change state | B23-VLVE-MOV-FTO | valves - motor operated - fail to change state |
+| B-23 | valves | motor operated modulating including valve operator | fail to operate | B23-VLVE-MOD-FTO | valves - motor operated modulating including valve operator - fail to operate |
+| B-23 | valves | motor operated modulating including valve operator | external leak | B23-VLVE-MOD-EXTLEAK | valves - motor operated modulating including valve operator - external leak |
+| B-23 | valves | motor operated modulating including valve operator | plugged | B23-VLVE-MOD-PLUG | valves - motor operated modulating including valve operator - plugged |
+| B-23 | valves | motor operated modulating including valve operator | rupture | B23-VLVE-MOD-RUPTURE | valves - motor operated modulating including valve operator - rupture |
+| B-23 | valves | air solenoid | fail to change state | B23-VLVE-AIRSOLENOID-FTO | valves - air solenoid - fail to change state |
+| B-23 | valves | air solenoid modulating includes valve operator | fail to operate | B23-VLVE-AIRMOD-FTO | valves - air solenoid modulating includes valve operator - fail to operate |
+| B-23 | valves | air solenoid modulating includes valve operator | external leak | B23-VLVE-AIRMOD-EXTLEAK | valves - air solenoid modulating includes valve operator - external leak |
+| B-23 | valves | air solenoid modulating includes valve operator | rupture | B23-VLVE-AIRMOD-RUPTURE | valves - air solenoid modulating includes valve operator - rupture |
+| B-23 | valves | manual | fail to operate | B23-VLVE-MANUAL-FTO | valves - manual - fail to operate |
+| B-23 | valves | manual | external leak | B23-VLVE-MANUAL-EXTLEAK | valves - manual - external leak |
+| B-23 | valves | check | fail to change state | B23-VLVE-CHK-FTO | valves - check - fail to change state |
+| B-23 | valves | check | reverse leak | B23-VLVE-CHK-RVRSLEAK | valves - check - reverse leak |
+| B-23 | valves | check | external leak | B23-VLVE-CHK-EXTLEAK | valves - check - external leak |
+| B-23 | valves | check | rupture | B23-VLVE-CHK-RUPTURE | valves - check - rupture |
+| B-23 | valves | hydraulic valve actuator | all | B23-VLVE-HYDRLIC-ALL | valves - hydraulic valve actuator - all |
+| B-23 | valves | pneumatic valve actuator | all | B23-VLVE-PNEUM-ALL | valves - pneumatic valve actuator - all |
+| B-23 | valves | relief (steam/water) | fail to open | B23-VLVE-RELIEFS/W-FTO | valves - relief (steam/water) - fail to open |
+| B-23 | valves | relief (steam/water) | spurious/premature operation | B23-VLVE-RELIEFS/W-SOP | valves - relief (steam/water) - spurious/premature operation |
+| B-23 | valves | relief (steam/water) | fail to reclose | B23-VLVE-RELIEFS/W-RECLOSE | valves - relief (steam/water) - fail to reclose |
+| B-23 | valves | motor operated helium isolation ring valve with redundant motors | fail to change state | B23-VLVE-HEMOVISOLATE-FTO | valves - motor operated helium isolation ring valve with redundant motors - fail to change state |
+| B-23 | valves | motor operated helium isolation ring valve with redundant motors | spurious/premature operation | B23-VLVE-HEMOVISOLATE-SOP | valves - motor operated helium isolation ring valve with redundant motors - spurious/premature operation |
+| B-23 | valves | motor operated helium isolation ring valve with redundant motors | bypass leak | B23-VLVE-HEMOVISOLATE-BYPSLEAK | valves - motor operated helium isolation ring valve with redundant motors - bypass leak |
+| B-23 | valves | passive helium isolation check valve | fail to change state | B23-VLVE-HEPASSISOLATE-FTO | valves - passive helium isolation check valve - fail to change state |
+| B-23 | valves | passive helium isolation check valve | spurious/premature operation | B23-VLVE-HEPASSISOLATE-SOP | valves - passive helium isolation check valve - spurious/premature operation |
+| B-23 | valves | passive helium isolation check valve | bypass leak | B23-VLVE-HEPASSISOLATE-BYPSLEAK | valves - passive helium isolation check valve - bypass leak |
+| B-23 | valves | orifice flow valve (helium) | external leak/rupture | B23-VLVE-FLOW-EXTLEAK | valves - orifice flow valve (helium) - external leak/rupture |
+| B-24 | diesel generator | all | fail to start and load on first try | B24-DG-ALL-FTS | diesel generator - all - fail to start and load on first try |
+| B-24 | diesel generator | all | standby failures | B24-DG-ALL-STNDBY | diesel generator - all - standby failures |
+| B-24 | diesel generator | all | fail to run | B24-DG-ALL-FTR | diesel generator - all - fail to run |
+| B-25 | Instrumentation | general | all | B25-INSTRUMNT-GENERAL-ALL | Instrumentation - general - all |
+| B-25 | Instrumentation | solid state instrumentation | fail to operate | B25-INSTRUMNT-SS-FTO | Instrumentation - solid state instrumentation - fail to operate |
+| B-25 | Instrumentation | solid state instrumentation | no output | B25-INSTRUMNT-SS-OUTPUT | Instrumentation - solid state instrumentation - no output |
+| B-25 | Instrumentation | solid state instrumentation | calibration shift | B25-INSTRUMNT-SS-CALIBRATION | Instrumentation - solid state instrumentation - calibration shift |
+| B-25 | Instrumentation | signal modifier | fail to operate | B25-INSTRUMNT-SIGMOD-FTO | Instrumentation - signal modifier - fail to operate |
+| B-25 | Instrumentation | signal modifier | setpoint drift | B25-INSTRUMNT-SIGMOD-DRIFT | Instrumentation - signal modifier - setpoint drift |
+| B-25 | Instrumentation | neutron flux sensor | fail to operate | B25-INSTRUMNT-NSENSOR-FTO | Instrumentation - neutron flux sensor - fail to operate |
+| B-25 | Instrumentation | pressure sensore | fail to operate | B25-INSTRUMNT-PRESENSOR-FTO | Instrumentation - pressure sensore - fail to operate |
+| B-25 | Instrumentation | temperature sensor | out of limits | B25-INSTRUMNT-TMPSENSOR-LIMITS | Instrumentation - temperature sensor - out of limits |
+| B-25 | Instrumentation | speed sensore | out of limits | B25-INSTRUMNT-SPDSENSOR-LIMIT | Instrumentation - speed sensore - out of limits |
+| B-25 | Instrumentation | moisture monitor sensor | out of limits | B25-INSTRUMNT-MOSTSENSOR-LIMIT | Instrumentation - moisture monitor sensor - out of limits |
+| B-25 | Instrumentation | position level sensor | out of limits | B25-INSTRUMNT-LVLSENSOR-LIMIT | Instrumentation - position level sensor - out of limits |
+| B-25 | Instrumentation | flow and level sensor | fail to operate | B25-INSTRUMNT-FLWSENSOR-FTO | Instrumentation - flow and level sensor - fail to operate |
+| B-26 | control | main steam pressure control | fail to operate | B26-CNTRL-MSPRESSURE-FTO | control - main steam pressure control - fail to operate |
+| B-26 | control | main steam pressure control | drift | B26-CNTRL-MSPRESSURE-DRIFT | control - main steam pressure control - drift |
+| B-26 | control | regulating rod control | fail to operate | B26-CNTRL-REGULATE-FTO | control - regulating rod control - fail to operate |
+| B-26 | control | regulating rod control | drift | B26-CNTRL-REGULATE-DRIFT | control - regulating rod control - drift |
+| B-26 | control | plant protection control | spurious signal terminates feedwater flow | B26-CNTRL-PROTECT-SOP | control - plant protection control - spurious signal terminates feedwater flow |
+| B-26 | control | signal conditioning system | fail to operate | B26-CNTRL-SIGCOND-FTO | control - signal conditioning system - fail to operate |
+| B-26 | control | steamline radiation monitoring | fail to operate | B26-CNTRL-RADMONIT-FTO | control - steamline radiation monitoring - fail to operate |
+| B-26 | control | turbine control | out of limits | B26-CNTRL-TURBINE-LIMIT | control - turbine control - out of limits |
+| B-26 | control | condensor control | out of limits | B26-CNTRL-CNDNSER-LIMIT | control - condensor control - out of limits |
+| B-26 | control | pressure switch | fail to operate | B26-CNTRL-PRESWITCH-FTO | control - pressure switch - fail to operate |
+| B-27 | service | instrument air | fail to operate | B27-SERVICE-INSTRUMNTAIR-FTO | service - instrument air - fail to operate |
+| B-27 | service | service water | fail to operate | B27-SERVICE-SWS-FTO | service - service water - fail to operate |
+| B-27 | service | offsite power | all | B27-SERVICE-OFFSITEPOWER-ALL | service - offsite power - all |
+| B-28 | motors | electric motors | fail to operate | B28-MOTOR-EM-FTO | motors - electric motors - fail to operate |
+| B-28 | motors | electric motors | fail to run in extreme environment | B28-MOTOR-EM-FTR/X | motors - electric motors - fail to run in extreme environment |
+| B-29 | transformers | general | all | B29-TRNSFRMR-GENERAL-ALL | transformers - general - all |
+| B-29 | transformers | high voltage transformer | trip off line | B29-TRNSFRMR-HIGHV-TRIP | transformers - high voltage transformer - trip off line |
+| B-29 | transformers | low voltage transformer | trip off line | B29-TRNSFRMR-LOWV-TRIP | transformers - low voltage transformer - trip off line |
+| B-29 | transformers | low voltage transformer | open/short windings | B29-TRNSFRMR-LOWV-SHORT | transformers - low voltage transformer - open/short windings |
+| B-29 | transformers | low voltage transformer | short to ground | B29-TRNSFRMR-LOWV-GROUND | transformers - low voltage transformer - short to ground |
+| B-30 | batteries | general | all | B30-BATTERY-GENERAL-ALL | batteries - general - all |
+| B-30 | batteries | general | low output shortened | B30-BATTERY-GENERAL-SHORTEN | batteries - general - low output shortened |
+| B-30 | batteries | general | voltage regulation | B30-BATTERY-GENERAL-REGULATE | batteries - general - voltage regulation |
+| B-30 | batteries | charger | all | B30-BATTERY-CHARGER-ALL | batteries - charger - all |
+| B-31 | electric conductor | general | all | B31-CONDCT-GENERAL-ALL | electric conductor - general - all |
+| B-31 | power cable | general | open | B31-CONDCT-CABLE-OPEN | power cable - general - open |
+| B-31 | power cable | general | ground | B31-CONDCT-CABLE-GROUND | power cable - general - ground |
+| B-31 | signal wire | general | open | B31-CONDCT-WIRE-OPEN | signal wire - general - open |
+| B-31 | signal wire | general | ground | B31-CONDCT-WIRE-GROUND | signal wire - general - ground |
+| B-31 | signal wire | general | short to power | B31-CONDCT-WIRE-SHORT | signal wire - general - short to power |
+| B-32 | Circuit breaker | general | fail to change state | B32-BRKR-GENERAL-FTO | Circuit breaker - general - fail to change state |
+| B-32 | Circuit breaker | general | premature transfer | B32-BRKR-GENERAL-SOP | Circuit breaker - general - premature transfer |
+| B-33 | electric | inverter | fail to operate | B33-ELECTRIC-INVRTR-FTO | electric - inverter - fail to operate |


### PR DESCRIPTION
Added the lists of event trees, fault trees, and the top events of the fault trees in the root directory's README file.
Changed the repair events' names in the `data/README.md` file.
PREVIOUS REPAIR EVENT NAMING FORMAT: `b-xx`
CURRENT FORMAT: `B-xx`.